### PR TITLE
sqlalchemy 1.4.27

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,12 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python
+    - python >=3.6
     - importlib-metadata  # [py<38]
     - greenlet !=0.4.17   # [py3k]
 
 test:
   requires:
-    - mock  # [py27]
     - pip
   imports:
     - sqlalchemy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python
     - importlib-metadata  # [py<38]
     - greenlet !=0.4.17   # [py3k]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python
@@ -55,7 +54,7 @@ test:
     - pip check
 
 about:
-  home: http://www.sqlalchemy.org/
+  home: https://www.sqlalchemy.org/
   license: MIT
   license_file: LICENSE
   license_family: MIT
@@ -63,7 +62,7 @@ about:
   description: |
     SQLAlchemy is the Python SQL toolkit and Object Relational Mapper that
     gives application developers the full power and flexibility of SQL.
-  doc_url: http://docs.sqlalchemy.org/
+  doc_url: https://docs.sqlalchemy.org/
   dev_url: https://github.com/sqlalchemy/sqlalchemy
   doc_source_url: https://github.com/zzzeek/sqlalchemy/blob/master/doc/build/index.rst
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.22" %}
+{% set version = "1.4.27" %}
 
 package:
   name: sqlalchemy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/SQLAlchemy/SQLAlchemy-{{ version }}.tar.gz
-  sha256: ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8
+  sha256: d768359daeb3a86644f3854c6659e4496a3e6bba2b4651ecc87ce7ad415b320c
 
 build:
   number: 0


### PR DESCRIPTION
Update sqlalchemy to 1.4.27

Version change: bump version number from 1.4.22 to 1.4.27
Bug Tracker: new open issues https://github.com/sqlalchemy/sqlalchemy/issues
Upstream license:  License file:  https://github.com/sqlalchemy/sqlalchemy/blob/master/LICENSE
Upstream Changelog: https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html
Upstream setup.cfg:  https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_27/setup.cfg

The package sqlalchemy is mentioned inside the packages:
agate-sql | aiopg | airflow | alembic | asyncpgsa | blaze | celery | clickhouse-sqlalchemy | flask-admin | flask-appbuilder | flask-sqlalchemy | geoalchemy2 | ibis-framework | jupyterhub | marshmallow-sqlalchemy | omniscidb | pandasql | pydruid | pyhive | sqlalchemy-jsonfield | sqlalchemy-utils | zope.sqlalchemy |

Actions:
1. Remove python from the requirements/build section
2. Fix home and doc urls

Result:
- all-succeeded