### PR TITLE
Update to v2.0.37

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sqlalchemy" %}
-{% set version = "2.0.34" %}
+{% set version = "2.0.37" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/SQLAlchemy/sqlalchemy-{{ version }}.tar.gz
-  sha256: 10d8f36990dd929690666679b0f42235c159a7051534adb135728ee52828dd22
+  sha256: 12b28d99a9c14eaf4055810df1001557176716de0167b91026e648e65229bffb
 
 build:
   number: 0
@@ -25,7 +25,7 @@ requirements:
     - setuptools
   run:
     - python
-    - greenlet !=0.4.17  # [py<313]
+    - greenlet !=0.4.17  # [py<314]
     - importlib-metadata  # [py<38]
     - typing-extensions >=4.6.0
 
@@ -64,8 +64,8 @@ test:
   commands:
     - pip check
     # Error with test teardown closing sqlite database on python > 3.10 in a conda env.
-    - pytest -n8 test -m "not backend" -k "not aaa_profiling"  # [py<=310]
-    - pytest -n8 test -m "backend" -k "not aaa_profiling"
+    - pytest -n8 test -m "not backend" -k "not (aaa_profiling or test_pickle_rows_other_process)"  # [py<=310]
+    - pytest -n8 test -m "backend" -k "not (aaa_profiling or test_pickle_rows_other_process)"
 
 about:
   home: https://www.sqlalchemy.org/


### PR DESCRIPTION
sqlalchemy 2.0.37

**Destination channel:** defaults

### Links

- [PKG-6451](https://anaconda.atlassian.net/browse/PKG-6451)
- [Upstream repository](https://github.com/sqlalchemy/sqlalchemy/tree/rel_2_0_37)
- [Upstream changelog/diff](https://docs.sqlalchemy.org/en/20/changelog/changelog_20.html)

### Explanation of changes:

- Skip a new multiprocessing test on Windows that fails in CI

[PKG-6451]: https://anaconda.atlassian.net/browse/PKG-6451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ